### PR TITLE
Updating the notification plugin to use the new eventing framework

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,6 +23,7 @@
         "internal",
         "JNEXT",
         "frameworkModules",
+        "PluginResult",
         //Node
         "__dirname",
         "GLOBAL",

--- a/plugin/com.blackberry.notification/www/client.js
+++ b/plugin/com.blackberry.notification/www/client.js
@@ -19,6 +19,7 @@
 
 var _ID = "com.blackberry.notification",
     _self = {},
+    noop = function () {},
     Notification,
     globalId = 0,
     globalItemId = 0;
@@ -55,29 +56,13 @@ Notification = function (title, options) {
 
     id = generateId();
 
-    // itemId is required parameter that identifies the notification. If tag is provided it serves as an itemId, when tag isn't provided itemId is generated.
+    // itemId is required parameter that identifies the notification.
+    // If tag is provided it serves as an itemId, when tag isn't provided itemId is generated.
     if (!options.tag) {
         options.tag = generateItemId() + "_itemId";
     }
 
-    if (options.onerror || options.onshow) {
-        options.eventName = "notification.event_" + options.tag;
-
-        if (!window.webworks.event.isOn(options.eventName)) {
-            window.webworks.event.once(_ID, options.eventName, function (errorMsg) {
-                if (errorMsg) {
-                    if (options.onerror) {
-                        options.onerror();
-                    }
-                }
-                else if (options.onshow) {
-                    options.onshow();
-                }
-            });
-        }
-    }
-
-    window.webworks.exec(function () {}, function () {}, _ID, "notify", {'id': id, 'title': title, 'options': options});
+    window.webworks.exec(options.onshow || noop, options.onerror || noop, _ID, "notify", {'id': id, 'title': title, 'options': options});
 
     this.getId = function () {
         return id;
@@ -90,13 +75,13 @@ Notification.requestPermission = function (callback) {
 
 Notification.remove = function (tag) {
     if (tag) {
-        window.webworks.exec(function () {}, function () {}, _ID, "remove", {'tag': tag});
+        window.webworks.exec(noop, noop, _ID, "remove", {'tag': tag});
     }
 };
 
 Notification.prototype.close = function () {
     if (this.options && this.options.tag) {
-        window.webworks.exec(function () {}, function () {}, _ID, "remove", {'tag': this.options.tag});
+        window.webworks.exec(noop, noop, _ID, "remove", {'tag': this.options.tag});
     }
 };
 

--- a/test/integration/automatic/blackberry.notification.js
+++ b/test/integration/automatic/blackberry.notification.js
@@ -25,13 +25,13 @@ function testNotificationReadOnly(field) {
 }
 
 describe("Notification", function () {
-    
+
     it("permissions granted", function () {
         expect(testNotificationValue("permission", "granted"));
     });
 
     it("permissions read-only", function () {
-        expect(testNotificationReadOnly("permission"));   
+        expect(testNotificationReadOnly("permission"));
     });
 
     it("request permission does not trigger callback", function () {
@@ -49,7 +49,7 @@ describe("Notification", function () {
 
     it("can create a notification with a body", function () {
         var notification;
-        notification = new window.Notification("TestApp - Notification!", { 
+        notification = new window.Notification("TestApp - Notification!", {
             body : 'tap to dismiss'
         });
         expect(notification).toBeDefined();
@@ -72,29 +72,29 @@ describe("Notification", function () {
         var notification,
             exception;
         try {
-            notification =  new window.Notification(123); 
-        } catch (e) { 
+            notification =  new window.Notification(123);
+        } catch (e) {
             exception = true;
         }
 
         expect(exception).toEqual(true);
     });
-    
+
     describe("close", function () {
         it("can close a notification", function () {
             var errorFlag,
                 showFlag,
-                onError = jasmine.createSpy("onError callback").andCallFake(function () { 
-                    errorFlag = true; 
+                onError = jasmine.createSpy("onError callback").andCallFake(function () {
+                    errorFlag = true;
                 }),
-                onShow = jasmine.createSpy("onShow callback").andCallFake(function () { 
-                    showFlag = true; 
+                onShow = jasmine.createSpy("onShow callback").andCallFake(function () {
+                    showFlag = true;
                 }),
                 myNotification;
-                
+
             runs(function () {
                 myNotification = new window.Notification("You should not see this notification!", {
-                    'onerror' : onError, 
+                    'onerror' : onError,
                     'onshow' : onShow
                 });
             });
@@ -109,44 +109,25 @@ describe("Notification", function () {
                 expect(onShow).toHaveBeenCalled();
             });
         });
-        
-        it("events do not fire once notification is closed", function () {
-            var errorFlag,
-                showFlag,
-                onError = jasmine.createSpy("onError callback").andCallFake(function () { 
-                    errorFlag = true; 
-                }),
-                onShow = jasmine.createSpy("onShow callback").andCallFake(function () { 
-                    showFlag = true; 
-                }),
-                myNotification = new window.Notification("You should not see this notification!", {
-                    'onerror' : onError, 
-                    'onshow' : onShow
-                });
 
-            myNotification.close();
-
-            expect(onError).not.toHaveBeenCalled();
-            expect(onShow).not.toHaveBeenCalled();
-        });
     });
 
     describe("Notification.remove", function () {
         it("can remove a notification", function () {
             var errorFlag,
                 showFlag,
-                onError = jasmine.createSpy("onError callback").andCallFake(function () { 
-                    errorFlag = true; 
+                onError = jasmine.createSpy("onError callback").andCallFake(function () {
+                    errorFlag = true;
                 }),
-                onShow = jasmine.createSpy("onShow callback").andCallFake(function () { 
-                    showFlag = true; 
+                onShow = jasmine.createSpy("onShow callback").andCallFake(function () {
+                    showFlag = true;
                 }),
                 tagNotification;
-                
+
             runs(function () {
                 tagNotification = new window.Notification("You should not see this notification!", {
                     'tag' : "this is a tag",
-                    'onerror' : onError, 
+                    'onerror' : onError,
                     'onshow' : onShow
                 });
             });

--- a/test/unit/com.blackberry.notification/client.js
+++ b/test/unit/com.blackberry.notification/client.js
@@ -6,9 +6,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -123,11 +123,6 @@ describe("notification client creates Notification object attached to window", f
             expect(window.webworks.exec.mostRecentCall.args[4].options.tag).toBeDefined();
         });
 
-        it("should notify by calling 'once' event when there is a callback(s) provided", function () {
-            new Notification("N Title", {'onshow': onShow, 'onerror': onError});
-
-            expect(mockedWebworks.event.once).toHaveBeenCalledWith(_ID, jasmine.any(String), jasmine.any(Function));
-        });
 
         it("should throw an exception when title is not provided", function () {
             expect(function () {


### PR DESCRIPTION
Hint and unit tests pass. Integration tests don't pass atm, but I'm unsure if they are valid. The tests are related to callbacks not firing after a notification has been closed. It seems like we are no longer doing this and I wasn't sure if this was spec related or just testing a piece of the old implementation. @bryanhiggins Any thoughts?
