### PR TITLE
Removed jsdom from dependencies to avoid npm install error on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "jasmine-node": "1.0.7",
     "jWorkflow": "*",
     "wrench": "1.3.9",
-    "ncp": "*",
-    "jsdom": "0.6.0"
+    "ncp": "*"
   },
   "bundledDependencies": [
     "connect",


### PR DESCRIPTION
Fixed Issue: [#161](http://github.rim.net/webworks/BB10-WebWorks-Cordova/issues/161)
