### PR TITLE
Update deploy-mobile-spec to work with new cordova-incl.js file

### DIFF
--- a/scripts/conf.js
+++ b/scripts/conf.js
@@ -22,7 +22,7 @@ module.exports = {
     },
     MOBILE_SPEC_REPOS: {
         "dir": path.normalize(__dirname + "/../test/cordova-mobile-spec"),
-        "url": "https://github.com/apache/cordova-mobile-spec.git"
+        "url": "https://github.com/blackberry/cordova-mobile-spec.git"
     },
     ROOT: path.normalize(__dirname + "/../"),
     TEMP: path.normalize(__dirname + "/../temp/"),

--- a/scripts/mobile-spec.js
+++ b/scripts/mobile-spec.js
@@ -26,13 +26,10 @@ var jWorkflow = require("jWorkflow"),
     projectPath = path.join(baseDir, "test", "mobile-spec/app"),
     projectName = "CordovaMobileSpec";
 
-
 function updateCordovaJSVersion() {
-    var content = fs.readFileSync(path.join(projectPath, 'www', 'cordova.js'), 'utf-8'),
-        version = fs.readFileSync(path.join(projectPath, 'www', 'VERSION'), 'utf-8').replace('\n', ''),
-        regex = /VERSION='(.*)'.*$/gm,
-        newContent = content.replace(regex.exec(content)[1],  version);
-    fs.writeFileSync(path.join(projectPath, 'www', 'cordova.js'), newContent, 'utf-8');
+    var version = fs.readFileSync(path.join(projectPath, 'www', 'VERSION'), 'utf-8').replace('\n', ''),
+        content = fs.readFileSync(path.join(projectPath, 'www', 'cordova-' + version + '.js'), 'utf-8');
+    fs.writeFileSync(path.join(projectPath, 'www', 'cordova.blackberry10.js'), content, 'utf-8');
 }
 
 module.exports = function (branch, targetName, targetIP, targetType, targetPassword, mobileSpecBranch) {


### PR DESCRIPTION
mobile-spec has been changed to automatically pull in platform specific JS files

Here is the pull request into apache to split out bb10 from bbos:
https://github.com/apache/cordova-mobile-spec/pull/17

To test this change, you will need the bb10JsLoading branch:

```
jake deploy-mobile-spec[master,z10,169.254.0.1,device,qaqa,bb10JsLoading]
```
