### PR TITLE
remove es5 setting from jshint config

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -49,7 +49,6 @@
     ],
 
     "node" : false,
-    "es5" : true,
     "browser" : true,
     "unused": false,
     "boss" : false,


### PR DESCRIPTION
this was making `jake` fail
