### PR TITLE
Removing blackberry.system.hasPermission function as it is no longer necessary

### DIFF
--- a/plugin/com.blackberry.system/www/client.js
+++ b/plugin/com.blackberry.system/www/client.js
@@ -87,10 +87,6 @@ function defineReadOnlyField(obj, field, value) {
     });
 }
 
-_self.hasPermission = function (module) {
-    return getFieldValue("hasPermission", {"module": module});
-};
-
 _self.hasCapability = function (capability) {
     return getFieldValue("hasCapability", {"capability": capability});
 };


### PR DESCRIPTION
This function is no longer necessary since the architecture has changed since its creation. We no longer have a whitelist to determine if a feature has permission for a given domain. If the feature exists (i.e blackberry.system) then it was loaded and is accessible.
