### PR TITLE
Correct path for manual tests.

### DIFF
--- a/test/test-app/manual/framework/SpecRunner.htm
+++ b/test/test-app/manual/framework/SpecRunner.htm
@@ -31,7 +31,7 @@
             for (var i = 0; i < checkBoxes.length; i++) {
                 if (checkBoxes[i].checked)
                 {
-                    addScript("local:///manual/framework/spec/" + checkBoxes[i].value + ".js");
+                    addScript("local:///manual/spec/" + checkBoxes[i].value + ".js");
                 }
             }
             alert("The selected tests have been added, click the Run Jasmine button to execute the SpecRunner");
@@ -85,14 +85,13 @@
         <input type="checkbox" value="blackberry.invoke">blackberry.invoke</input><br />
         <input type="checkbox" value="blackberry.invoked">blackberry.invoked</input><br />
         <input type="checkbox" value="blackberry.invoke.card">blackberry.invoke.card</input><br />
-        <input type="checkbox" value="blackberry.ui.dialog">ui.dialog</input><br />
+        <input type="checkbox" value="blackberry.ui.dialog">blackberry.ui.dialog</input><br />
         <input type="checkbox" value="blackberry.io.filetransfer">blackberry.io.filetransfer</input><br />
         <input type="checkbox" value="blackberry.push">blackberry.push</input><br />
         <input type="checkbox" value="blackberry.system">blackberry.system</input><br />
         <input type="checkbox" value="blackberry.bbm.platform">blackberry.bbm.platform</input><br />
         <input type="checkbox" value="blackberry.pim.contacts">blackberry.pim.contacts</input><br />
         <input type="checkbox" value="blackberry.pim.calendar">blackberry.pim.calendar</input><br />
-        <input type="checkbox" value="ui/dialog/index">blackberry.ui.dialog</input><br />
         <input type="checkbox" value="blackberry.notification">blackberry.notification</input><br />
         <input type="checkbox" value="blackberry.ui.cover">blackberry.ui.cover</input><br />
     </form>


### PR DESCRIPTION
Remove confusing extra 'dialog' option from manual test page.
