### PR TITLE
Don't call pause and resume events from com.blackberry.app

### DIFF
--- a/plugin/com.blackberry.app/src/blackberry10/index.js
+++ b/plugin/com.blackberry.app/src/blackberry10/index.js
@@ -25,18 +25,6 @@ var _config = require("./../../lib/config"),
                 pluginResult.callbackOk(undefined, true);
             } 
         },
-        pause: {
-            event: "inactive",
-            trigger: function (pluginResult) {
-                pluginResult.callbackOk(undefined, true);
-            } 
-        },
-        resume: {
-            event: "active",
-            trigger: function (pluginResult) {
-                pluginResult.callbackOk(undefined, true);
-            } 
-        },
         orientationchange : {
             //special case, handled in add
             event: "rotate",


### PR DESCRIPTION
Cordova itself is responsible for these two events
