### PR TITLE
workaround cordova plugin add/remove breaking granddependent plugins

### DIFF
--- a/plugin/com.blackberry.connection/plugin.xml
+++ b/plugin/com.blackberry.connection/plugin.xml
@@ -25,6 +25,7 @@
     <license>Apache 2.0</license>
 
     <dependency id="com.blackberry.jpps"/>
+    <dependency id="com.blackberry.utils" />
 
     <js-module src="www/client.js">
         <clobbers target="blackberry.connection" />

--- a/plugin/com.blackberry.system/plugin.xml
+++ b/plugin/com.blackberry.system/plugin.xml
@@ -25,6 +25,7 @@
     <license>Apache 2.0</license>
 
     <dependency id="com.blackberry.jpps" />
+    <dependency id="com.blackberry.utils" />
 
     <js-module src="www/client.js">
         <clobbers target="blackberry.system" />


### PR DESCRIPTION
just explicitly depend on them
