### PR TITLE
Pin jshint to 2.4.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "elementtree": "0.1.5",
     "shelljs": "0.1.3"
   },
-  "dev-dependencies": {
+  "devDependencies": {
     "cordova": "*",
-    "jake": "0.7.13"
+    "jake": "0.7.13",
+    "jshint": "2.4.*"
   },
   "bundledDependencies": [
     "connect",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -38,7 +38,7 @@ function _lintJS() {
     var options = ["--reporter", "scripts/reporter.js"],
         files = ["."];
 
-    return utils.execCommandWithJWorkflow('jshint ' + files.concat(options).join(' '), {cwd: _c.TEMP});
+    return utils.execCommandWithJWorkflow(path.join(path.dirname(__dirname), 'node_modules', 'jshint', 'bin', 'jshint') + ' ' + files.concat(options).join(' '), {cwd: _c.TEMP});
 }
 
 function _lintCPP() {


### PR DESCRIPTION
2.5 doesn't have as much of an opinion about whitespace

jshint 2.5 wasn't complaining about things we were changing. With this change, npm install installs the version of jshint we expect to be using, so we get consistent results across computers.
