### PR TITLE
Change RIM to Forbes so ContactNews test passes

### DIFF
--- a/test/test-app/automatic/spec/blackberry.pim.contacts.js
+++ b/test/test-app/automatic/spec/blackberry.pim.contacts.js
@@ -1860,7 +1860,7 @@ describe("blackberry.pim.contacts", function () {
 
             contactObj = contacts.create({
                 "name": { familyName: "WebWorksTest", givenName: "John" },
-                "organizations": [ { name: "Research In Motion" } ]
+                "organizations": [ { name: "Forbes" } ]
             });
 
             try {


### PR DESCRIPTION
Because "RIM" changed its name it is no longer returning any content when queried
