### PR TITLE
CalendarEvent.save should pass updated event to success callback, but  it's not

### DIFF
--- a/plugin/com.blackberry.pim.calendar/src/blackberry10/native/pim_calendar_qt.cpp
+++ b/plugin/com.blackberry.pim.calendar/src/blackberry10/native/pim_calendar_qt.cpp
@@ -440,10 +440,6 @@ Json::Value PimCalendarQt::EditCalendarEvent(bbpim::CalendarEvent& calEvent, con
             }
 
             if (calEvent.isValid()) {
-                if (mutex_lock() == 0) {
-                    calEvent = service->event(calEvent.accountId(), calEvent.id());
-                    mutex_unlock();
-                }
                 returnObj["event"] = populateEvent(calEvent, false);
                 returnObj["_success"] = true;
             }


### PR DESCRIPTION
This issue happens on BB10 10.3.2, no such issue in earlier version.